### PR TITLE
ci: set up Docker Buildx and specify platforms for image build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,9 @@ jobs:
     - name: Check out the repo
       uses: actions/checkout@v3
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to Docker Hub
       uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
       with:
@@ -32,6 +35,7 @@ jobs:
       with:
         context: .
         file: ./apps/web/Dockerfile
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I haven't had a chance to test this. but I currently manage a arm machine in AWS and this was somewhat required step for me before I could use this project.